### PR TITLE
Add basic list and blockquote support

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,11 @@
-export type TsmarkNodeType = 'heading' | 'paragraph' | 'code_block';
+export type TsmarkNodeType =
+  | 'heading'
+  | 'paragraph'
+  | 'code_block'
+  | 'list'
+  | 'list_item'
+  | 'blockquote'
+  | 'thematic_break';
 export type TsmarkNode =
   | {
     type: 'heading';
@@ -12,4 +19,20 @@ export type TsmarkNode =
   | {
     type: 'code_block';
     content: string;
+  }
+  | {
+    type: 'list';
+    ordered: boolean;
+    items: TsmarkNode[];
+  }
+  | {
+    type: 'list_item';
+    children: TsmarkNode[];
+  }
+  | {
+    type: 'blockquote';
+    children: TsmarkNode[];
+  }
+  | {
+    type: 'thematic_break';
   };


### PR DESCRIPTION
## Summary
- extend node types to include lists, blockquotes and thematic breaks
- implement naive parsing for lists, blockquotes and thematic breaks
- convert parsed nodes to HTML with very simple inline formatting

## Testing
- `deno fmt src/tsmark.ts src/types.d.ts`
- `deno task test` *(fails: AssertionError at example 5)*

------
https://chatgpt.com/codex/tasks/task_e_68686b3a6a0c832cb46324a8113fa66a