### PR TITLE
Fix partial CommonMark escapes

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -207,14 +207,19 @@ function nodeToHTML(node: TsmarkNode): string {
 }
 
 function escapeHTML(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(
-    />/g,
-    '&gt;',
-  );
+  return text.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\"/g, '&quot;');
 }
 
 function inlineToHTML(text: string): string {
   let out = escapeHTML(text);
+  // handle backslash escapes for punctuation characters
+  // see CommonMark Spec 6. Backslash escapes
+  out = out.replace(/\\([!"#$%&'()*+,\-.\/\:;<=>?@\[\]\\^_`{|}~])/g, '$1');
+  // backslash at line end creates hard line break
+  out = out.replace(/\\\n/g, '<br />\n');
   out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
   out = out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
   out = out.replace(/__([^_]+)__/g, '<strong>$1</strong>');


### PR DESCRIPTION
## Summary
- support escaping double quotes in HTML output
- parse backslash escapes and line breaks

## Testing
- `deno task test` *(fails: 138 passed, 514 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6868706d795c832ca8a218395cd6eaf6