### PR TITLE
Improve autolink handling

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -237,13 +237,6 @@ function escapeHTML(text: string): string {
 function inlineToHTML(text: string): string {
   const placeholders: string[] = [];
 
-  // store HTML tags as placeholders
-  text = text.replace(/<\/?[A-Za-z][^>]*>/g, (m) => {
-    const token = `\u0000${placeholders.length}\u0000`;
-    placeholders.push(m);
-    return token;
-  });
-
   // store autolinks as placeholders
   text = text.replace(/<([a-zA-Z][a-zA-Z0-9+.-]*:[^\s<>]*)>/g, (_, p1) => {
     const token = `\u0000${placeholders.length}\u0000`;
@@ -253,6 +246,13 @@ function inlineToHTML(text: string): string {
   text = text.replace(/<([^\s@<>]+@[^\s@<>]+)>/g, (_, p1) => {
     const token = `\u0000${placeholders.length}\u0000`;
     placeholders.push(`<a href="mailto:${p1}">${escapeHTML(p1)}</a>`);
+    return token;
+  });
+
+  // store HTML tags as placeholders
+  text = text.replace(/<\/?[A-Za-z](?![A-Za-z0-9+.-]*:)[^>]*>/g, (m) => {
+    const token = `\u0000${placeholders.length}\u0000`;
+    placeholders.push(m);
     return token;
   });
 


### PR DESCRIPTION
## Summary
- refine inline HTML parser
- handle autolinks before HTML parsing and avoid mis-parsing

## Testing
- `DENO_TLS_CA_STORE=system deno task test -- 599`
- `DENO_TLS_CA_STORE=system deno task test -- 600`
- `DENO_TLS_CA_STORE=system deno task test -- 601`
- `DENO_TLS_CA_STORE=system deno task test -- 602`
- `DENO_TLS_CA_STORE=system deno task test -- 603`
- `DENO_TLS_CA_STORE=system deno task test -- 604`
- `DENO_TLS_CA_STORE=system deno task test -- 605`
- `DENO_TLS_CA_STORE=system deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686890a9ddc4832ca4fdafa4e2a7691f