### PR TITLE
Fix list item indentation

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -97,7 +97,7 @@ export function parse(md: string): TsmarkNode[] {
         const m = lines[i].match(/^(\s{0,3})([-+*])([ \t]+.*)$/);
         if (!m) break;
         const markerIndent = indentWidth(m[1]) + 2;
-        const itemLines: string[] = [m[3]];
+        const itemLines: string[] = [stripColumns(m[3], markerIndent)];
         i++;
         while (i < lines.length) {
           const ind = indentWidth(lines[i]);


### PR DESCRIPTION
## Summary
- handle indentation after list markers when parsing list items

## Testing
- `DENO_CERT=/etc/ssl/certs/ca-certificates.crt deno task test`


------
https://chatgpt.com/codex/tasks/task_e_68689e49988c832ca92b270ba3976786