### PR TITLE
Fix paragraph break loop

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -185,7 +185,7 @@ export function parse(md: string): TsmarkNode[] {
     if (line.trim() !== '') {
       const paraLines: string[] = [];
       while (i < lines.length && lines[i].trim() !== '') {
-        if (/^\s{0,3}[-+*]\s+/.test(lines[i])) break;
+        if (/^\s{0,3}[-+*][ \t]+/.test(lines[i])) break;
         paraLines.push(lines[i]);
         i++;
       }


### PR DESCRIPTION
## Summary
- avoid endless loop by matching bullet indicator with ASCII spaces only

## Testing
- `deno task test -- 353` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6868e7e683d0832cb7dba91fa494e43b