### PR TITLE
Improve basic parsing

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -265,7 +265,7 @@ function inlineToHTML(text: string, refs?: Map<string, RefDef>): string {
   const placeholders: string[] = [];
 
   // store code spans as placeholders before any other processing
-  text = text.replace(/(`+)([\s\S]*?)\1/g, (_, _p1, p2) => {
+  text = text.replace(/(?<!\\)(`+)([\s\S]*?)\1/g, (_, _p1, p2) => {
     const token = `\u0002${placeholders.length}\u0002`;
     placeholders.push(`<code>${escapeHTML(p2.trim())}</code>`);
     return token;
@@ -437,5 +437,5 @@ export function convertToHTML(md: string): string {
   const nodes = parse(filtered.join('\n'));
   return nodes.map((node) => {
     return nodeToHTML(node, refs);
-  }).join('') + '\n';
+  }).join('\n') + '\n';
 }


### PR DESCRIPTION
## Summary
- improve code span parsing to respect backslash escapes
- separate block elements in HTML output with newlines

## Testing
- `DENO_CERT=/usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt deno task test`
- `DENO_CERT=/usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt deno task test -- 14`

------
https://chatgpt.com/codex/tasks/task_e_6868ed33d054832ca3e831d32998fe8b