### PR TITLE
Fix HTML block handling

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,8 @@ export type TsmarkNodeType =
   | 'list'
   | 'list_item'
   | 'blockquote'
-  | 'thematic_break';
+  | 'thematic_break'
+  | 'html';
 export type TsmarkNode =
   | {
     type: 'heading';
@@ -35,4 +36,8 @@ export type TsmarkNode =
   }
   | {
     type: 'thematic_break';
+  }
+  | {
+    type: 'html';
+    content: string;
   };


### PR DESCRIPTION
## Summary
- treat standalone HTML tags as blocks
- include HTML block node type

## Testing
- `DENO_TLS_CA_STORE=system deno task test -- 21`
- `DENO_TLS_CA_STORE=system deno task test`

------
https://chatgpt.com/codex/tasks/task_e_6868fb521b50832ca2a75d364c8284a4