### PR TITLE
Fix parser tests stepwise

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ export type TsmarkNode =
   | {
     type: 'code_block';
     content: string;
+    language?: string;
   }
   | {
     type: 'list';


### PR DESCRIPTION
## Summary
- support language info in fenced code blocks
- implement HTML entity decoding and numeric entity handling
- ensure links and references decode entities and escape properly
- treat character references as plain text when parsing

## Testing
- `DENO_TLS_CA_STORE=system deno task test -- 22`
- `DENO_TLS_CA_STORE=system deno task test -- 23`
- `DENO_TLS_CA_STORE=system deno task test -- 24`
- `DENO_TLS_CA_STORE=system deno task test -- 25`
- `DENO_TLS_CA_STORE=system deno task test -- 26`
- `DENO_TLS_CA_STORE=system deno task test -- 27`
- `DENO_TLS_CA_STORE=system deno task test -- 32`
- `DENO_TLS_CA_STORE=system deno task test -- 34`
- `DENO_TLS_CA_STORE=system deno task test -- 37`
- `DENO_TLS_CA_STORE=system deno task test -- 38`
- `DENO_TLS_CA_STORE=system deno task test -- 39`
- `DENO_TLS_CA_STORE=system deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686913b6dc68832c9cba3d3ebd5d9a55