### PR TITLE
Improve list parsing

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,10 +26,12 @@ export type TsmarkNode =
     type: 'list';
     ordered: boolean;
     items: TsmarkNode[];
+    loose?: boolean;
   }
   | {
     type: 'list_item';
     children: TsmarkNode[];
+    loose?: boolean;
   }
   | {
     type: 'blockquote';


### PR DESCRIPTION
## Summary
- support ordered list parsing
- preserve list tightness and render tight lists correctly

## Testing
- `deno task test`


------
https://chatgpt.com/codex/tasks/task_e_6869d671e3f0832c835f337951b29515