### PR TITLE
Fix HTML block ending newline

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -377,13 +377,24 @@ export function parse(md: string): TsmarkNode[] {
         const htmlLines: string[] = [stripped];
         i++;
         if (['pre', 'script', 'style', 'textarea'].includes(tag)) {
+          let closed = false;
           while (i < lines.length) {
-            htmlLines.push(stripLazy(lines[i]));
-            if (new RegExp(`</${tag}>`, 'i').test(stripLazy(lines[i]))) {
+            const ln = stripLazy(lines[i]);
+            htmlLines.push(ln);
+            if (new RegExp(`</${tag}>`, 'i').test(ln)) {
               i++;
+              closed = true;
               break;
             }
             i++;
+          }
+          if (!closed) {
+            while (
+              htmlLines.length > 0 &&
+              htmlLines[htmlLines.length - 1].trim() === ''
+            ) {
+              htmlLines.pop();
+            }
           }
         } else {
           while (i < lines.length && stripLazy(lines[i]).trim() !== '') {


### PR DESCRIPTION
## Summary
- trim blank lines from unterminated HTML blocks
- update markdown parser accordingly

## Testing
- `deno task test -- --unsafely-ignore-certificate-errors=jsr.io`
- `deno task test -- 173 --unsafely-ignore-certificate-errors=jsr.io`


------
https://chatgpt.com/codex/tasks/task_e_6869e06deab0832c9d4b4a572ad91fc5