### PR TITLE
Fix empty inline link handling

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -783,6 +783,13 @@ function inlineToHTML(text: string, refs?: Map<string, RefDef>): string {
     },
   );
 
+  // inline links with empty destination
+  text = text.replace(/\[([^\]]+)\]\(\)/g, (_, textContent) => {
+    const token = `\u0000${placeholders.length}\u0000`;
+    placeholders.push(`<a href="">${escapeHTML(unescapeMd(textContent))}</a>`);
+    return token;
+  });
+
   // reference-style images
   if (refs) {
     text = text.replace(


### PR DESCRIPTION
## Summary
- support inline links with empty destinations

## Testing
- `deno test --allow-read --unsafely-ignore-certificate-errors=jsr.io ./tests/test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6869f56f8cb0832cbe65144863917cb7