### PR TITLE
Improve link parsing

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -775,7 +775,6 @@ function inlineToHTML(text: string, refs?: Map<string, RefDef>): string {
   text = text.replace(
     /\[((?:\\.|[^\]])*)\]\((<[^>]*>|[^\s)]+)(?:\s+"([^"]+)")?\)/g,
     (m, textContent, href, title) => {
-      if (href.includes('\u0001')) return m;
       if (href.startsWith('<') && !href.endsWith('>')) return m;
       const token = `\u0000${placeholders.length}\u0000`;
       let link = restoreEntities(restoreEscapes(href));


### PR DESCRIPTION
## Summary
- fix link parsing when the href contains escaped characters

## Testing
- `deno task test -- 22`
- `deno task test` *(fails: 159 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686a1f71ff5c832ca553396849650720