### PR TITLE
Fix emphasis handling for underscores

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -916,11 +916,11 @@ function inlineToHTML(text: string, refs?: Map<string, RefDef>): string {
     '<strong>$1</strong>',
   );
   out = out.replace(
-    /__([^_\s](?:[^_]*[^_\s])?)__(?!_)/g,
+    /__([^_\s](?:[^_]*[^_\s])?)__/g,
     '<strong>$1</strong>',
   );
   out = out.replace(/\*([^*\s](?:[^*]*[^*\s])?)\*(?!\*)/g, '<em>$1</em>');
-  out = out.replace(/_([^_\s](?:[^_]*[^_\s])?)_(?!_)/g, '<em>$1</em>');
+  out = out.replace(/_([^_\s](?:[^_]*[^_\s])?)_/g, '<em>$1</em>');
 
   // trim spaces before emphasis at line start
   out = out.replace(/(^|\n)\s+(?=<(?:em|strong)>)/g, '$1');


### PR DESCRIPTION
## Summary
- improve emphasis regex so `_foo____` is parsed correctly

## Testing
- `DENO_TLS_CA_STORE=system deno task test -- 459`
- `DENO_TLS_CA_STORE=system deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686a2500dd0c832c962910fa303be583