### PR TITLE
Fix blockquote continuation and ordered list start

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,6 +26,7 @@ export type TsmarkNode =
     type: 'list';
     ordered: boolean;
     items: TsmarkNode[];
+    start?: number;
     loose?: boolean;
   }
   | {


### PR DESCRIPTION
## Summary
- handle lazy lines inside blockquotes
- treat blank lines followed by another blockquote as a new quote
- fix list indentation and capture ordered list start number
- emit `start` attribute for ordered lists

## Testing
- `deno task test` *(fails: 518 passed, 134 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686a2b6e40c8832cbca266eb3dc113b3