### PR TITLE
Fix blockquote split on blank line

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -237,9 +237,7 @@ export function parse(md: string): TsmarkNode[] {
           prevBlank = false;
           i++;
         } else if (current.trim() === '') {
-          bqLines.push('');
-          prevBlank = true;
-          i++;
+          break;
         } else if (
           fence === null &&
           indentWidth(lines[i]) <= 3 &&


### PR DESCRIPTION
## Summary
- adjust blockquote parsing to stop at blank lines without `>` prefix
- update formatting

## Testing
- `DENO_CERT=/usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt deno task test -- 242`
- `DENO_CERT=/usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686a3dbfee54832c980ea335da94965b