### PR TITLE
Fix paragraph-blockquote separation

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -545,6 +545,7 @@ export function parse(md: string): TsmarkNode[] {
             /^ {0,3}(\*\s*){3,}$/.test(stripLazy(lines[i])) ||
             /^ {0,3}(-\s*){3,}$/.test(stripLazy(lines[i])) ||
             /^ {0,3}(_\s*){3,}$/.test(stripLazy(lines[i])) ||
+            /^ {0,3}>/.test(stripLazy(lines[i])) ||
             /^\s{0,3}[-+*][ \t]+/.test(stripLazy(lines[i])) ||
             /^ {0,3}#{1,6}(?:\s|$)/.test(stripLazy(lines[i])) ||
             (() => {


### PR DESCRIPTION
## Summary
- stop paragraph parsing when encountering a blockquote start

## Testing
- `deno task test -- 245`
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686a43061768832c93875a8074a179fb