### PR TITLE
Fix blockquote parsing edge case

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -234,7 +234,7 @@ export function parse(md: string): TsmarkNode[] {
             }
           }
           bqLines.push(rest);
-          prevBlank = false;
+          prevBlank = rest.trim() === '';
           i++;
         } else if (current.trim() === '') {
           break;


### PR DESCRIPTION
## Summary
- handle blank lines inside blockquotes correctly

## Testing
- `DENO_TLS_CA_STORE=system deno task test`


------
https://chatgpt.com/codex/tasks/task_e_686a48aac588832c8fa8c671ce9630e3