### PR TITLE
Fix list item blank line parsing

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -325,7 +325,11 @@ export function parse(md: string): TsmarkNode[] {
             let j = i + 1;
             while (j < lines.length && stripLazy(lines[j]).trim() === '') j++;
             const nextInd = j < lines.length ? indentWidth(lines[j]) : -1;
-            if (nextInd >= markerIndent) {
+            const atStart = itemLines.every((ln) => ln.trim() === '');
+            if (
+              nextInd >= markerIndent &&
+              (!atStart || nextInd >= markerIndent + 4)
+            ) {
               itemLoose = true;
               itemLines.push('');
               i++;


### PR DESCRIPTION
## Summary
- handle list items that start with a blank line correctly
- adjust parsing so that a blank line does not extend an empty item unless next line is indented

## Testing
- `deno task test -- 280`
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686a5d43842c832c897ff827dab17d1c