### PR TITLE
Fix list looseness for indented code

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -368,6 +368,13 @@ export function parse(md: string): TsmarkNode[] {
               break;
             }
             if (nextInd >= markerIndent + 4) {
+              const prevLine = itemLines[itemLines.length - 1] ?? '';
+              const prevBullet = isOrdered
+                ? /^\s*\d+[.)]/.test(prevLine)
+                : /^\s*[-+*]/.test(prevLine);
+              if (!prevBullet && prevLine.trim() !== '') {
+                itemLoose = true;
+              }
               itemLines.push('');
               i++;
               prevBlank = true;


### PR DESCRIPTION
## Summary
- handle blank lines before indented code blocks when determining loose lists
- ensure list items preceding code blocks are marked loose only when appropriate

## Testing
- `deno task test -- 5`
- `deno task test -- 306`
- `deno task test` *(fails: 573 passed, 79 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686af62d2524832c927ea0a7305b50dc