### PR TITLE
Fix code span parsing

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -899,7 +899,7 @@ function inlineToHTML(
 ): string {
   // store code spans as placeholders before any other processing
   text = text.replace(
-    /(?<![\\"'=])(`+)([\s\S]*?)(?<!`)\1(?!`)/g,
+    /(?<![\\"'=`])(`+)(?!`)([\s\S]*?)(?<!`)\1(?!`)/g,
     (full, p1, p2, offset, str) => {
       const start = offset;
       const end = offset + full.length;


### PR DESCRIPTION
## Summary
- avoid misparsing code spans when backtick sequences are part of a larger run

## Testing
- `deno task test -- 346`
- `deno task test` *(fails: 584 passed, 68 failed)*

------
https://chatgpt.com/codex/tasks/task_e_686b428684fc832c875a40f05a54a031