### PR TITLE
Fix emphasis tagging across HTML placeholders

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -1365,6 +1365,7 @@ function applyEmphasisOnce(text: string): string {
   }
 
   function isPunctuation(ch: string): boolean {
+    if (ch === '<' || ch === '>') return false;
     return /[\p{P}\p{S}]/u.test(ch);
   }
 


### PR DESCRIPTION
## Summary
- tweak punctuation detection so `<` and `>` don't block emphasis markers
- run tests and improve pass count

## Testing
- `deno task test -- 415`
- `deno task test -- 416`
- `deno task test`


------
https://chatgpt.com/codex/tasks/task_e_686bbbe1ada8832cb1971e4001407572