### PR TITLE
Fix angle-bracket links with empty URLs

### DIFF
--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -1152,7 +1152,7 @@ function inlineToHTML(
 
   // inline links (direct) with angle brackets around destination
   text = text.replace(
-    /\[([^\[\]]*)\]\(<([^\n>]+)>[ \t\n]*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|\(((?:\\.|[^)\\])*)\))?\)/g,
+    /\[([^\[\]]*)\]\(<([^\n>]*)>[ \t\n]*(?:"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|\(((?:\\.|[^)\\])*)\))?\)/g,
     (m, textContent, href, t1, t2, t3) => {
       const title = t1 || t2 || t3;
       const decodedHref = decodeEntities(


### PR DESCRIPTION
## Summary
- handle empty destinations for links written with angle brackets

## Testing
- `deno task test -- 485`
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686bc0b14370832caaf50696ff5a99b0