### PR TITLE
Extract thematic break parsing

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -4,6 +4,7 @@ import { paragraphToHTML } from './nodes/paragraph.ts';
 import { codeBlockToHTML } from './nodes/code_block.ts';
 import { listToHTML } from './nodes/list.ts';
 import { blockquoteToHTML } from './nodes/blockquote.ts';
+import { thematicBreakToHTML } from './nodes/thematic_break.ts';
 import {
   indentWidth,
   isValidLabel,
@@ -26,7 +27,7 @@ function nodeToHTML(node: TsmarkNode, refs?: Map<string, RefDef>): string {
   } else if (node.type === 'blockquote') {
     return blockquoteToHTML(node, (n) => nodeToHTML(n, refs), refs);
   } else if (node.type === 'thematic_break') {
-    return '<hr />';
+    return thematicBreakToHTML(node);
   } else if (node.type === 'html') {
     return node.content;
   }

--- a/src/nodes/paragraph.ts
+++ b/src/nodes/paragraph.ts
@@ -1,6 +1,7 @@
 import type { RefDef, TsmarkNode } from '../types.d.ts';
 import { inlineToHTML } from './inline.ts';
 import { parseSetextHeading } from './heading.ts';
+import { parseThematicBreak } from './thematic_break.ts';
 import { indentWidth, LAZY, stripColumns, stripLazy } from '../utils.ts';
 
 const htmlBlockStartRegex = /^ {0,3}<\/?([A-Za-z][A-Za-z0-9-]*)(?=[\s/>]|$)/;
@@ -89,9 +90,7 @@ export function parseParagraph(
     }
     if (
       !lines[i].startsWith(LAZY) && (
-        /^ {0,3}(\*\s*){3,}$/.test(stripLazy(lines[i])) ||
-        /^ {0,3}(-\s*){3,}$/.test(stripLazy(lines[i])) ||
-        /^ {0,3}(_\s*){3,}$/.test(stripLazy(lines[i])) ||
+        parseThematicBreak(stripLazy(lines[i])) !== null ||
         /^ {0,3}>/.test(stripLazy(lines[i])) ||
         /^\s{0,3}[-+*][ \t]+/.test(stripLazy(lines[i])) ||
         (() => {

--- a/src/nodes/thematic_break.ts
+++ b/src/nodes/thematic_break.ts
@@ -1,0 +1,18 @@
+import type { TsmarkNode } from '../types.d.ts';
+
+export function parseThematicBreak(line: string): TsmarkNode | null {
+  if (
+    /^ {0,3}(\*\s*){3,}$/.test(line) ||
+    /^ {0,3}(-\s*){3,}$/.test(line) ||
+    /^ {0,3}(_\s*){3,}$/.test(line)
+  ) {
+    return { type: 'thematic_break' };
+  }
+  return null;
+}
+
+export function thematicBreakToHTML(
+  _node: TsmarkNode & { type: 'thematic_break' },
+): string {
+  return '<hr />';
+}

--- a/src/tsmark.ts
+++ b/src/tsmark.ts
@@ -4,6 +4,7 @@ import { parseParagraph } from './nodes/paragraph.ts';
 import { parseCodeBlock } from './nodes/code_block.ts';
 import { parseList } from './nodes/list.ts';
 import { parseBlockquote } from './nodes/blockquote.ts';
+import { parseThematicBreak } from './nodes/thematic_break.ts';
 import {
   caseFold,
   encodeHref,
@@ -97,12 +98,9 @@ export function parse(md: string): TsmarkNode[] {
     const stripped = stripLazy(line);
 
     // thematic break
-    if (
-      /^ {0,3}(\*\s*){3,}$/.test(stripped) ||
-      /^ {0,3}(-\s*){3,}$/.test(stripped) ||
-      /^ {0,3}(_\s*){3,}$/.test(stripped)
-    ) {
-      nodes.push({ type: 'thematic_break' });
+    const tbNode = parseThematicBreak(stripped);
+    if (tbNode) {
+      nodes.push(tbNode);
       i++;
       continue;
     }


### PR DESCRIPTION
## Summary
- create `thematic_break` node module
- refactor parser and HTML converter to use the new module
- update paragraph parsing to recognize thematic breaks via the new function

## Testing
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686cfeb56c50832ca4a973fe193b9c9a