### PR TITLE
Move ToHTML functions

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -1,11 +1,11 @@
 import type { RefDef, TsmarkNode } from './types.d.ts';
-import { headingToHTML } from './nodes/heading.ts';
-import { paragraphToHTML } from './nodes/paragraph.ts';
-import { codeBlockToHTML } from './nodes/code_block.ts';
-import { listToHTML } from './nodes/list.ts';
-import { blockquoteToHTML } from './nodes/blockquote.ts';
-import { thematicBreakToHTML } from './nodes/thematic_break.ts';
-import { htmlToHTML } from './nodes/html.ts';
+import { headingToHTML } from './html/heading.ts';
+import { paragraphToHTML } from './html/paragraph.ts';
+import { codeBlockToHTML } from './html/code_block.ts';
+import { listToHTML } from './html/list.ts';
+import { blockquoteToHTML } from './html/blockquote.ts';
+import { thematicBreakToHTML } from './html/thematic_break.ts';
+import { htmlToHTML } from './html/html.ts';
 import {
   indentWidth,
   isValidLabel,

--- a/src/html/blockquote.ts
+++ b/src/html/blockquote.ts
@@ -1,0 +1,12 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+
+export function blockquoteToHTML(
+  node: TsmarkNode & { type: 'blockquote' },
+  toHTML: (node: TsmarkNode) => string,
+  refs?: Map<string, RefDef>,
+): string {
+  const inner = node.children.map((n) => toHTML(n)).join('\n');
+  return inner === ''
+    ? '<blockquote>\n</blockquote>'
+    : `<blockquote>\n${inner}\n</blockquote>`;
+}

--- a/src/html/code_block.ts
+++ b/src/html/code_block.ts
@@ -1,0 +1,13 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+import { escapeHTML } from '../utils.ts';
+
+export function codeBlockToHTML(
+  node: TsmarkNode & { type: 'code_block' },
+  _refs?: Map<string, RefDef>,
+): string {
+  const escaped = escapeHTML(node.content);
+  const langClass = node.language
+    ? ` class="language-${escapeHTML(node.language)}"`
+    : '';
+  return `<pre><code${langClass}>${escaped}</code></pre>`;
+}

--- a/src/html/heading.ts
+++ b/src/html/heading.ts
@@ -1,0 +1,9 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+import { inlineToHTML } from '../nodes/inline.ts';
+
+export function headingToHTML(
+  node: TsmarkNode & { type: 'heading' },
+  refs?: Map<string, RefDef>,
+): string {
+  return `<h${node.level}>${inlineToHTML(node.content, refs)}</h${node.level}>`;
+}

--- a/src/html/html.ts
+++ b/src/html/html.ts
@@ -1,0 +1,8 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+
+export function htmlToHTML(
+  node: TsmarkNode & { type: 'html' },
+  _refs?: Map<string, RefDef>,
+): string {
+  return node.content;
+}

--- a/src/html/list.ts
+++ b/src/html/list.ts
@@ -1,0 +1,65 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+import { inlineToHTML } from '../nodes/inline.ts';
+
+function listItemToHTML(
+  item: TsmarkNode & { type: 'list_item' },
+  loose: boolean,
+  toHTML: (node: TsmarkNode) => string,
+  refs?: Map<string, RefDef>,
+): string {
+  const [first, ...rest] = item.children;
+  if (!first) {
+    return '<li></li>';
+  }
+  if (first.type === 'paragraph') {
+    const firstHTML = inlineToHTML(first.content, refs);
+    const restHTML = rest.map((n) => {
+      if (n.type === 'paragraph' && !loose) {
+        return inlineToHTML(n.content, refs);
+      }
+      return toHTML(n);
+    }).join('\n');
+    if (!loose) {
+      if (rest.length === 0) {
+        return `<li>${firstHTML}</li>`;
+      }
+      return `<li>${firstHTML}\n${restHTML}\n</li>`;
+    }
+    if (rest.length === 0) {
+      return loose
+        ? `<li>\n<p>${firstHTML}</p>\n</li>`
+        : `<li><p>${firstHTML}</p></li>`;
+    }
+    return `<li>\n<p>${firstHTML}</p>\n${restHTML}\n</li>`;
+  }
+  const inner = [first, ...rest].map((n) => {
+    if (n.type === 'paragraph' && !loose) {
+      return inlineToHTML(n.content, refs);
+    }
+    return toHTML(n);
+  }).join('\n');
+  const trailing =
+    item.children[item.children.length - 1]?.type === 'paragraph' && !loose
+      ? ''
+      : '\n';
+  return `<li>\n${inner}${trailing}</li>`;
+}
+
+export function listToHTML(
+  node: TsmarkNode & { type: 'list' },
+  toHTML: (node: TsmarkNode) => string,
+  refs?: Map<string, RefDef>,
+): string {
+  const items = node.items.map((it) => {
+    if (it.type === 'list_item') {
+      return listItemToHTML(it, node.loose ?? false, toHTML, refs);
+    }
+    return `<li>${toHTML(it)}</li>`;
+  }).join('\n');
+  const tag = node.ordered ? 'ol' : 'ul';
+  const attr = node.ordered && (node as any).start !== undefined &&
+      (node as any).start !== 1
+    ? ` start="${(node as any).start}"`
+    : '';
+  return `<${tag}${attr}>\n${items}\n</${tag}>`;
+}

--- a/src/html/paragraph.ts
+++ b/src/html/paragraph.ts
@@ -1,0 +1,9 @@
+import type { RefDef, TsmarkNode } from '../types.d.ts';
+import { inlineToHTML } from '../nodes/inline.ts';
+
+export function paragraphToHTML(
+  node: TsmarkNode & { type: 'paragraph' },
+  refs?: Map<string, RefDef>,
+): string {
+  return `<p>${inlineToHTML(node.content, refs)}</p>`;
+}

--- a/src/html/thematic_break.ts
+++ b/src/html/thematic_break.ts
@@ -1,0 +1,7 @@
+import type { TsmarkNode } from '../types.d.ts';
+
+export function thematicBreakToHTML(
+  _node: TsmarkNode & { type: 'thematic_break' },
+): string {
+  return '<hr />';
+}

--- a/src/nodes/blockquote.ts
+++ b/src/nodes/blockquote.ts
@@ -1,4 +1,4 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
+import type { TsmarkNode } from '../types.d.ts';
 import { indentWidth, LAZY, stripColumns, stripLazy } from '../utils.ts';
 
 export function parseBlockquote(
@@ -72,15 +72,4 @@ export function parseBlockquote(
 
   const children = parseFn(bqLines.join('\n'));
   return { node: { type: 'blockquote', children }, next: i };
-}
-
-export function blockquoteToHTML(
-  node: TsmarkNode & { type: 'blockquote' },
-  toHTML: (node: TsmarkNode) => string,
-  refs?: Map<string, RefDef>,
-): string {
-  const inner = node.children.map((n) => toHTML(n)).join('\n');
-  return inner === ''
-    ? '<blockquote>\n</blockquote>'
-    : `<blockquote>\n${inner}\n</blockquote>`;
 }

--- a/src/nodes/code_block.ts
+++ b/src/nodes/code_block.ts
@@ -1,7 +1,6 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
+import type { TsmarkNode } from '../types.d.ts';
 import {
   decodeEntities,
-  escapeHTML,
   indentWidth,
   stripColumns,
   stripIndent,
@@ -89,15 +88,4 @@ export function parseCodeBlock(
   }
 
   return null;
-}
-
-export function codeBlockToHTML(
-  node: TsmarkNode & { type: 'code_block' },
-  _refs?: Map<string, RefDef>,
-): string {
-  const escaped = escapeHTML(node.content);
-  const langClass = node.language
-    ? ` class="language-${escapeHTML(node.language)}"`
-    : '';
-  return `<pre><code${langClass}>${escaped}</code></pre>`;
 }

--- a/src/nodes/heading.ts
+++ b/src/nodes/heading.ts
@@ -1,5 +1,4 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
-import { inlineToHTML } from './inline.ts';
+import type { TsmarkNode } from '../types.d.ts';
 
 export function parseATXHeading(line: string): TsmarkNode | null {
   const atx = line.match(/^ {0,3}(#{1,6})(.*)$/);
@@ -25,11 +24,4 @@ export function parseSetextHeading(
   const level = nextLine.trim().startsWith('=') ? 1 : 2;
   const content = paraLines.join('\n').trimEnd();
   return { type: 'heading', level, content };
-}
-
-export function headingToHTML(
-  node: TsmarkNode & { type: 'heading' },
-  refs?: Map<string, RefDef>,
-): string {
-  return `<h${node.level}>${inlineToHTML(node.content, refs)}</h${node.level}>`;
 }

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1,4 +1,4 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
+import type { TsmarkNode } from '../types.d.ts';
 import { isHtmlTag, stripLazy } from '../utils.ts';
 
 export const htmlBlockStartRegex =
@@ -151,11 +151,4 @@ export function parseHtmlBlock(
   }
 
   return null;
-}
-
-export function htmlToHTML(
-  node: TsmarkNode & { type: 'html' },
-  _refs?: Map<string, RefDef>,
-): string {
-  return node.content;
 }

--- a/src/nodes/list.ts
+++ b/src/nodes/list.ts
@@ -1,5 +1,4 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
-import { inlineToHTML } from './inline.ts';
+import type { TsmarkNode } from '../types.d.ts';
 import {
   indentWidth,
   indentWidthFrom,
@@ -181,67 +180,4 @@ export function parseList(
     return { node: listNode as TsmarkNode, next: i };
   }
   return null;
-}
-
-function listItemToHTML(
-  item: TsmarkNode & { type: 'list_item' },
-  loose: boolean,
-  toHTML: (node: TsmarkNode) => string,
-  refs?: Map<string, RefDef>,
-): string {
-  const [first, ...rest] = item.children;
-  if (!first) {
-    return '<li></li>';
-  }
-  if (first.type === 'paragraph') {
-    const firstHTML = inlineToHTML(first.content, refs);
-    const restHTML = rest.map((n) => {
-      if (n.type === 'paragraph' && !loose) {
-        return inlineToHTML(n.content, refs);
-      }
-      return toHTML(n);
-    }).join('\n');
-    if (!loose) {
-      if (rest.length === 0) {
-        return `<li>${firstHTML}</li>`;
-      }
-      return `<li>${firstHTML}\n${restHTML}\n</li>`;
-    }
-    if (rest.length === 0) {
-      return loose
-        ? `<li>\n<p>${firstHTML}</p>\n</li>`
-        : `<li><p>${firstHTML}</p></li>`;
-    }
-    return `<li>\n<p>${firstHTML}</p>\n${restHTML}\n</li>`;
-  }
-  const inner = [first, ...rest].map((n) => {
-    if (n.type === 'paragraph' && !loose) {
-      return inlineToHTML(n.content, refs);
-    }
-    return toHTML(n);
-  }).join('\n');
-  const trailing =
-    item.children[item.children.length - 1]?.type === 'paragraph' && !loose
-      ? ''
-      : '\n';
-  return `<li>\n${inner}${trailing}</li>`;
-}
-
-export function listToHTML(
-  node: TsmarkNode & { type: 'list' },
-  toHTML: (node: TsmarkNode) => string,
-  refs?: Map<string, RefDef>,
-): string {
-  const items = node.items.map((it) => {
-    if (it.type === 'list_item') {
-      return listItemToHTML(it, node.loose ?? false, toHTML, refs);
-    }
-    return `<li>${toHTML(it)}</li>`;
-  }).join('\n');
-  const tag = node.ordered ? 'ol' : 'ul';
-  const attr = node.ordered && (node as any).start !== undefined &&
-      (node as any).start !== 1
-    ? ` start="${(node as any).start}"`
-    : '';
-  return `<${tag}${attr}>\n${items}\n</${tag}>`;
 }

--- a/src/nodes/paragraph.ts
+++ b/src/nodes/paragraph.ts
@@ -1,5 +1,4 @@
-import type { RefDef, TsmarkNode } from '../types.d.ts';
-import { inlineToHTML } from './inline.ts';
+import type { TsmarkNode } from '../types.d.ts';
 import { parseSetextHeading } from './heading.ts';
 import { parseThematicBreak } from './thematic_break.ts';
 import { htmlBlockStartRegex, htmlBlockTags } from './html.ts';
@@ -85,11 +84,4 @@ export function parseParagraph(
     };
   }
   return null;
-}
-
-export function paragraphToHTML(
-  node: TsmarkNode & { type: 'paragraph' },
-  refs?: Map<string, RefDef>,
-): string {
-  return `<p>${inlineToHTML(node.content, refs)}</p>`;
 }

--- a/src/nodes/thematic_break.ts
+++ b/src/nodes/thematic_break.ts
@@ -10,9 +10,3 @@ export function parseThematicBreak(line: string): TsmarkNode | null {
   }
   return null;
 }
-
-export function thematicBreakToHTML(
-  _node: TsmarkNode & { type: 'thematic_break' },
-): string {
-  return '<hr />';
-}


### PR DESCRIPTION
## Summary
- extract HTML conversion functions into `src/html/`
- remove HTML helpers from parser node files
- update imports in `convertToHTML`

## Testing
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686d026dff1c832cb1941564dd0e392f