### PR TITLE
Refactor: add braces for single-line blocks

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -44,22 +44,44 @@ export function convertToHTML(md: string): string {
   const lines = md.replace(/\r\n?/g, '\n').split('\n');
   let prevWasDef = false;
   function canStartDef(idx: number): boolean {
-    if (idx === 0) return true;
+    if (idx === 0) {
+      return true;
+    }
     const prev = lines[idx - 1];
-    if (prev.trim() === '') return true;
-    if (prevWasDef) return true;
-    if (startDef.test(prev)) return true;
-    if (/^ {0,3}\[$/.test(prev)) return true;
-    if (/^ {0,3}#{1,6}\s/.test(prev)) return true;
-    if (/^ {0,3}>/.test(prev)) return true;
-    if (/^ {0,3}(?:\d{1,9}[.)]|[-+*])(?:\s|$)/.test(prev)) return true;
-    if (/^ {0,3}(`{3,}|~{3,})/.test(prev)) return true;
+    if (prev.trim() === '') {
+      return true;
+    }
+    if (prevWasDef) {
+      return true;
+    }
+    if (startDef.test(prev)) {
+      return true;
+    }
+    if (/^ {0,3}\[$/.test(prev)) {
+      return true;
+    }
+    if (/^ {0,3}#{1,6}\s/.test(prev)) {
+      return true;
+    }
+    if (/^ {0,3}>/.test(prev)) {
+      return true;
+    }
+    if (/^ {0,3}(?:\d{1,9}[.)]|[-+*])(?:\s|$)/.test(prev)) {
+      return true;
+    }
+    if (/^ {0,3}(`{3,}|~{3,})/.test(prev)) {
+      return true;
+    }
     if (
       /^ {0,3}(?:\*\s*){3,}$/.test(prev) ||
       /^ {0,3}(?:-\s*){3,}$/.test(prev) ||
       /^ {0,3}(?:_\s*){3,}$/.test(prev)
-    ) return true;
-    if (indentWidth(prev) >= 4) return true;
+    ) {
+      return true;
+    }
+    if (indentWidth(prev) >= 4) {
+      return true;
+    }
     return false;
   }
   let fence: { char: string; len: number } | null = null;

--- a/src/nodes/blockquote.ts
+++ b/src/nodes/blockquote.ts
@@ -7,7 +7,9 @@ export function parseBlockquote(
   parseFn: (md: string) => TsmarkNode[],
 ): { node: TsmarkNode; next: number } | null {
   const first = stripLazy(lines[start]);
-  if (!/^ {0,3}>/.test(first)) return null;
+  if (!/^ {0,3}>/.test(first)) {
+    return null;
+  }
 
   let i = start;
   const bqLines: string[] = [];
@@ -47,7 +49,9 @@ export function parseBlockquote(
       !/^(?:\s*)(`{3,}|~{3,})/.test(current) &&
       !/^ {0,3}(?:\d{1,9}[.)]|[-+*])(?:\s|$)/.test(current)
     ) {
-      if (prevBlank) break;
+      if (prevBlank) {
+        break;
+      }
       bqLines.push(
         LAZY + stripColumns(lines[i], Math.min(indentWidth(lines[i]), 3)),
       );
@@ -67,7 +71,9 @@ export function parseBlockquote(
       );
       prevBlank = false;
       i++;
-    } else break;
+    } else {
+      break;
+    }
   }
 
   const children = parseFn(bqLines.join('\n'));

--- a/src/nodes/code_block.ts
+++ b/src/nodes/code_block.ts
@@ -29,12 +29,20 @@ export function parseCodeBlock(
       let i = start + 1;
       const codeLines: string[] = [];
       function isClosing(ln: string): boolean {
-        if (indentWidth(ln) > 3) return false;
+        if (indentWidth(ln) > 3) {
+          return false;
+        }
         const trimmed = ln.trimStart();
-        if (!trimmed.startsWith(fence[0])) return false;
+        if (!trimmed.startsWith(fence[0])) {
+          return false;
+        }
         let cnt = 0;
-        while (cnt < trimmed.length && trimmed[cnt] === fence[0]) cnt++;
-        if (cnt < fence.length) return false;
+        while (cnt < trimmed.length && trimmed[cnt] === fence[0]) {
+          cnt++;
+        }
+        if (cnt < fence.length) {
+          return false;
+        }
         return trimmed.slice(cnt).trim() === '';
       }
       while (i < lines.length) {

--- a/src/nodes/heading.ts
+++ b/src/nodes/heading.ts
@@ -2,7 +2,9 @@ import type { TsmarkNode } from '../types.d.ts';
 
 export function parseATXHeading(line: string): TsmarkNode | null {
   const atx = line.match(/^ {0,3}(#{1,6})(.*)$/);
-  if (!atx) return null;
+  if (!atx) {
+    return null;
+  }
   const level = atx[1].length;
   let rest = atx[2];
   if (rest !== '' && !/^\s/.test(rest)) {
@@ -19,8 +21,12 @@ export function parseSetextHeading(
   paraLines: string[],
   nextLine: string,
 ): TsmarkNode | null {
-  if (paraLines.length === 0) return null;
-  if (!/^ {0,3}([-=])+\s*$/.test(nextLine)) return null;
+  if (paraLines.length === 0) {
+    return null;
+  }
+  if (!/^ {0,3}([-=])+\s*$/.test(nextLine)) {
+    return null;
+  }
   const level = nextLine.trim().startsWith('=') ? 1 : 2;
   const content = paraLines.join('\n').trimEnd();
   return { type: 'heading', level, content };

--- a/src/nodes/inline.ts
+++ b/src/nodes/inline.ts
@@ -152,7 +152,9 @@ export function inlineToHTML(
       while (i < text.length) {
         const ch = text[i];
         if (quote) {
-          if (ch === quote) quote = null;
+          if (ch === quote) {
+            quote = null;
+          }
           i++;
           continue;
         }
@@ -236,7 +238,9 @@ export function inlineToHTML(
           if (ch === '[') depth++;
           else if (ch === ']') {
             depth--;
-            if (depth === 0) break;
+            if (depth === 0) {
+              break;
+            }
           }
           j++;
         }
@@ -255,7 +259,9 @@ export function inlineToHTML(
             else if (ch === '(' && angle === 0) pd++;
             else if (ch === ')' && angle === 0) {
               pd--;
-              if (pd === 0) break;
+              if (pd === 0) {
+                break;
+              }
             }
             k++;
           }
@@ -346,7 +352,9 @@ export function inlineToHTML(
       let out = '';
       for (let i = 0; i < str.length;) {
         let isImage = false;
-        if (str[i] === '!' && str[i + 1] === '[') isImage = true;
+        if (str[i] === '!' && str[i + 1] === '[') {
+          isImage = true;
+        }
         if (isImage || str[i] === '[') {
           const start = isImage ? i + 1 : i;
           let j = start + 1;
@@ -568,7 +576,9 @@ export function applyEmphasisOnce(text: string): string {
   }
 
   function isPunctuation(ch: string): boolean {
-    if (ch === '<' || ch === '>') return false;
+    if (ch === '<' || ch === '>') {
+      return false;
+    }
     return /[\p{P}\p{S}]/u.test(ch);
   }
 
@@ -578,7 +588,9 @@ export function applyEmphasisOnce(text: string): string {
     const ch = text[i];
     if (ch === '*' || ch === '_') {
       let j = i;
-      while (j < text.length && text[j] === ch) j++;
+      while (j < text.length && text[j] === ch) {
+        j++;
+      }
       const count = j - i;
       const prev = i === 0 ? '' : text[i - 1];
       const next = j >= text.length ? '' : text[j];
@@ -608,14 +620,20 @@ export function applyEmphasisOnce(text: string): string {
   const stack: Delim[] = [];
   for (let idx = 0; idx < tokens.length; idx++) {
     const t = tokens[idx];
-    if (!t.delim) continue;
+    if (!t.delim) {
+      continue;
+    }
     const d = t.delim;
     if (d.canClose) {
       let openerIndex = -1;
       for (let j = stack.length - 1; j >= 0; j--) {
         const op = stack[j];
-        if (op.char !== d.char) continue;
-        if (!op.canOpen) continue;
+        if (op.char !== d.char) {
+          continue;
+        }
+        if (!op.canOpen) {
+          continue;
+        }
         if (
           (op.canClose || d.canOpen) && ((op.count + d.count) % 3 === 0) &&
           (op.count % 3 !== 0 || d.count % 3 !== 0)

--- a/src/nodes/list.ts
+++ b/src/nodes/list.ts
@@ -93,7 +93,9 @@ export function parseList(
             continue;
           }
           let j = i + 1;
-          while (j < lines.length && stripLazy(lines[j]).trim() === '') j++;
+          while (j < lines.length && stripLazy(lines[j]).trim() === '') {
+            j++;
+          }
           const next = j < lines.length ? stripLazy(lines[j]) : '';
           const nextMatch = isOrdered
             ? next.match(/^(\s{0,3})(\d{1,9})([.)])((?:[ \t]+.*)?)$/)
@@ -110,7 +112,9 @@ export function parseList(
           }
           if (nextInd >= markerIndent + 4) {
             let k = itemLines.length - 1;
-            while (k >= 0 && itemLines[k].trim() === '') k--;
+            while (k >= 0 && itemLines[k].trim() === '') {
+              k--;
+            }
             const prevLine = k >= 0 ? itemLines[k] : '';
             const prevBullet = isOrdered
               ? /^\s*\d+[.)]/.test(prevLine)
@@ -125,7 +129,9 @@ export function parseList(
           }
           if (nextInd >= markerIndent && !atStart) {
             let k2 = itemLines.length - 1;
-            while (k2 >= 0 && itemLines[k2].trim() === '') k2--;
+            while (k2 >= 0 && itemLines[k2].trim() === '') {
+              k2--;
+            }
             const prevLine = k2 >= 0 ? itemLines[k2] : '';
             const prevBullet = isOrdered
               ? /^\s*\d+[.)]/.test(prevLine)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -165,7 +165,9 @@ export function isValidLabel(text: string): boolean {
     if (ch === '[') {
       depth++;
     } else if (ch === ']') {
-      if (depth === 0) return false;
+      if (depth === 0) {
+        return false;
+      }
       depth--;
     } else if (ch.trim() !== '') {
       hasNonSpace = true;


### PR DESCRIPTION
## Summary
- apply consistent brace usage across parser implementation

## Testing
- `deno fmt --check`
- `deno task test`

------
https://chatgpt.com/codex/tasks/task_e_686d073eea40832c9a291a21eabdefaa